### PR TITLE
update sw.js to specify cache for embedded dashboard endpoints

### DIFF
--- a/frontend/src/metabase/sw.js
+++ b/frontend/src/metabase/sw.js
@@ -21,6 +21,25 @@ workbox.routing.registerRoute(({ url, request, sameOrigin }) => {
 }, new workbox.strategies.StaleWhileRevalidate());
 
 workbox.routing.registerRoute(
+  ({ url }) => url.pathname.startsWith("/api/embed/dashboard/"),
+  new workbox.strategies.NetworkFirst({
+    cacheName: "embedded-dashboard-cache",
+    plugins: [
+      new workbox.cacheableResponse.CacheableResponsePlugin({
+        statuses: [200, 202],
+      }),
+      new workbox.expiration.ExpirationPlugin({
+        maxAgeSeconds: 365 * 24 * 60 * 60,
+      }),
+    ],
+    cacheKeyWillBeUsed: async ({ request }) => {
+      const fullUrl = request.url;
+      const cacheKey = new URL(fullUrl).pathname;
+      return cacheKey;
+    },
+  }),
+);
+workbox.routing.registerRoute(
   ({ url }) => url.pathname.startsWith("/api/"),
   new workbox.strategies.NetworkOnly(),
   "POST",


### PR DESCRIPTION
Closes https://github.com/catalpainternational/openly_dird/issues/2073

### Description

Enables embedded dashboards to be loaded offline from the cache, by adding some more detail to the `NetworkFirst` strategy.
- Specifies a cache for embedded dashboard urls, and also ensures **all** nested urls are included in the cache (previously it was just capturing e.g. `api/embed/dashboard/aeiou`, and not `api/embed/dashboard/aeiou/dashcard/20/card/17`)
- The service worker will now properly store these responses in a special `embedded-dashboard-cache`, which it will be able to fall back to when the user is offline

### How to verify
Open up the embedded dashboard in a new tab and open the dev tools. Refresh the page to register the service worker (you should see an influx of `workbox` logs in the console to verify this), then check the Application > Storage > Cache Storage > embedded-dashboard-cache to ensure the responses have been stored. If you then toggle the network throttling to offline and refresh the page, you'll see the service worker is loading these responses from the cache.

Note: After starting the backend (`clojure -M:run`) you'll need to run `yarn build` to ensure the service worker file has been updated - verify that the code at http://localhost:3000/service-worker.js matches the changes in this PR before running `yarn build-hot` 
